### PR TITLE
Fix yaml tensor kinds and NEW_EMBODIMENT support in leapp export

### DIFF
--- a/export/joint_name_parser.py
+++ b/export/joint_name_parser.py
@@ -375,7 +375,6 @@ EMBODIMENT_JOINT_REGISTRY: Dict[str, Dict[str, Dict[str, List[str]]]] = {
     },
 }
 
-
 # =============================================================================
 # Utility Functions
 # =============================================================================
@@ -471,14 +470,75 @@ def get_joint_names(
     
     if group_name is None:
         return modality_joints
-    
+
     if group_name not in modality_joints:
+        # Fallback: effort_<x> keys (feed-forward torques) map to the same joints
+        # as their position counterpart <x>. Lets users add effort outputs to their
+        # modality config without duplicating joint-name registrations.
+        if group_name.startswith("effort_"):
+            base_key = group_name[len("effort_"):]
+            if base_key in modality_joints:
+                return modality_joints[base_key]
+
         raise ValueError(
             f"Group '{group_name}' not found in {embodiment_tag}/{modality_type}. "
             f"Available: {list(modality_joints.keys())}"
         )
-    
+
     return modality_joints[group_name]
+
+
+def register_embodiment_joints(
+    embodiment_tag: Union[str, EmbodimentTag],
+    joints: Dict[str, Dict[str, List[str]]],
+    base_embodiment: Optional[Union[str, EmbodimentTag]] = None,
+) -> None:
+    """Register a new embodiment in the joint registry.
+
+    This is the programmatic equivalent of ``register_modality_config`` in GR00T.
+    Use it to support fine-tunes with ``EmbodimentTag.NEW_EMBODIMENT`` or custom
+    embodiments not in the pre-registered registry.
+
+    Args:
+        embodiment_tag: The embodiment identifier to register.
+        joints: Mapping of ``modality_type`` ("state"/"action") to a mapping of
+            ``group_name`` to a list of joint names.  Only keys you supply are
+            stored; merging with a base embodiment is controlled via
+            ``base_embodiment``.
+        base_embodiment: Optional embodiment to copy joints from before applying
+            overrides.  Useful when a custom embodiment is a variant of an
+            existing one (e.g. a different whole-body controller on the same
+            robot).
+
+    Example::
+
+        register_embodiment_joints(
+            EmbodimentTag.NEW_EMBODIMENT,
+            joints={},  # use everything from unitree_g1
+            base_embodiment="unitree_g1",
+        )
+    """
+    import copy as _copy
+
+    if isinstance(embodiment_tag, EmbodimentTag):
+        embodiment_tag = embodiment_tag.value
+
+    if base_embodiment is not None:
+        if isinstance(base_embodiment, EmbodimentTag):
+            base_embodiment = base_embodiment.value
+        if base_embodiment not in EMBODIMENT_JOINT_REGISTRY:
+            raise ValueError(
+                f"Base embodiment '{base_embodiment}' not in registry. "
+                f"Available: {list(EMBODIMENT_JOINT_REGISTRY.keys())}"
+            )
+        merged = _copy.deepcopy(EMBODIMENT_JOINT_REGISTRY[base_embodiment])
+    else:
+        merged = {}
+
+    for modality_type, groups in joints.items():
+        merged.setdefault(modality_type, {}).update(groups)
+
+    EMBODIMENT_JOINT_REGISTRY[embodiment_tag] = merged
 
 
 def get_flat_joint_names(

--- a/export/policy_modifications.py
+++ b/export/policy_modifications.py
@@ -95,8 +95,8 @@ def get_action_traceable(self, data, initial_noise=None):
         for k, v in unbatched_observations[i]["video"].items():
 
             unbatched_observations[i]["video"][k] = annotate.input_tensors(
-                'preprocess_video', TensorSemantics(name=k, ref = v, 
-                                                    kind = "state/video")
+                'preprocess_video', TensorSemantics(name=k, ref = v,
+                                                    kind = "state/camera/image")
             )
 
     # Step 2: Process each observation through the VLA processor
@@ -173,13 +173,32 @@ def get_action_traceable(self, data, initial_noise=None):
         normalized_action, self.embodiment_tag, batched_states
     )
 
-    # # Cast all actions to float32 for consistency
-    casted_action = [TensorSemantics(name=key, ref = value.to(torch.float32),
-                    kind = OutputKindEnum.JOINT_POSITION,
-                    element_names = get_joint_names(self.embodiment_tag, "action", key)) for key, value in unnormalized_action.items()]
-    
+    # Cast all actions to float32 for consistency.  Pick the right `kind` per output:
+    #   - effort_* keys     -> target/joint/effort
+    #   - navigate_command  -> velocity_command (downstream convention)
+    #   - base_height_command -> no kind (scalar standing-height target)
+    #   - everything else   -> target/joint/position (arms/hands/waist)
+    def _kind_for(output_key: str):
+        if output_key.startswith("effort_"):
+            return OutputKindEnum.JOINT_EFFORT
+        if output_key == "navigate_command":
+            return "velocity_command"
+        if output_key == "base_height_command":
+            return None
+        return OutputKindEnum.JOINT_POSITION
 
-    annotate.output_tensors('decode_action', casted_action, 
+    casted_action = [
+        TensorSemantics(
+            name=key,
+            ref=value.to(torch.float32),
+            kind=_kind_for(key),
+            element_names=get_joint_names(self.embodiment_tag, "action", key),
+        )
+        for key, value in unnormalized_action.items()
+    ]
+
+
+    annotate.output_tensors('decode_action', casted_action,
                             export_with='onnx')
 
     return casted_action, {}


### PR DESCRIPTION
Two commits addressing issues hit when using this export tool with finetuned GR00T N1.6 models against the deployment stack.

## Problem

Every time we export a finetuned GR00T policy, the downstream deployment team has to hand-edit the generated yaml before they can use it:

1. **Video input kind** is \`state/video\`, which isn't a registered kind on the deployment side. Should be \`state/camera/image\`.

2. **All action outputs get \`OutputKindEnum.JOINT_POSITION\`**, even when the policy outputs feed-forward torques, navigation velocity commands, or scalar base-height targets. Effort outputs should be \`target/joint/effort\`, \`navigate_command\` is a \`velocity_command\`, and \`base_height_command\` shouldn't carry a joint-kind at all.

3. **\`EmbodimentTag.NEW_EMBODIMENT\` exports fail** outright with \`Embodiment 'new_embodiment' not in joint registry\`, because the registry is a static hardcoded dict with no hook for user finetunes.

4. **Adding \`effort_*\` outputs to a custom modality config fails** with \`Group 'effort_left_arm' not found\`, because effort keys aren't separately registered even though the underlying joints are identical to the position counterpart.

## Fixes in this PR

### \`joint_name_parser.py\`

- Auto-fallback: \`effort_<x>\` group lookups fall back to \`<x>\` joint list. No duplication needed.
- New \`register_embodiment_joints(tag, joints, base_embodiment=...)\` helper: programmatic equivalent of GR00T's \`register_modality_config\`. Mirrors the registration pattern finetune users already know.

### \`policy_modifications.py\`

- Video input kind: \`state/video\` -> \`state/camera/image\`.
- Action output kind chosen per-key:
  - \`effort_*\` -> \`OutputKindEnum.JOINT_EFFORT\`
  - \`navigate_command\` -> \`\"velocity_command\"\`
  - \`base_height_command\` -> \`None\`
  - default -> \`OutputKindEnum.JOINT_POSITION\`

## Validation

Tested end-to-end with a G1 \`NEW_EMBODIMENT\` finetune that trains joint positions, arm feed-forward torques, and navigation/base-height commands. Before the PR: yaml required hand-editing on every export. After: yaml is deploy-ready for the joint-kind concerns (tensor-name prefix mismatches and \`element_names\` nesting format remain separate issues that appear to live in the leapp library itself).

## Does not address

- Tensor name prefixes in the generated yaml (\`vl_input_*\`, \`action_inputs_*\`, \`backbone_outputs_*\`, \`state_0_*\`) not matching the actual ONNX graph input/output names. This happens inside \`leapp.annotate\`.
- \`element_names\` serializing as 1-level \`[[joint_names]]\` rather than the 2-level \`[[], [joint_names]]\` that downstream tooling expects.

Happy to follow up on either if they turn out to be fixable from this repo side.