### PR TITLE
Align producer/consumer tensor names so yaml matches ONNX

### DIFF
--- a/export/policy_modifications.py
+++ b/export/policy_modifications.py
@@ -25,27 +25,42 @@ from joint_name_parser import get_joint_names
 def _backbone_forward_with_int32(self, vl_input):
     """
     Backbone forward that converts boolean outputs to int32 for TensorRT compatibility.
-    
+
     Note: TensorRT doesn't support int8 as a general data type (only for INT8 quantization),
     so we use int32 instead which has full TensorRT support.
-    
+
     Calls self._original_forward which is the original forward method.
+
+    The local variable holding the result is named ``backbone_outputs`` so that
+    leapp's auto-generated tensor names (which include the local variable name)
+    already match the parameter name (``backbone_outputs``) of the downstream
+    ``action_head.get_action`` consumer.  Without this alignment, leapp's
+    cross-node name reconciler rewrites the names *only* in the yaml metadata
+    after the ONNX file has been exported, producing yaml output that disagrees
+    with the actual ONNX graph.
     """
     outputs = self._original_forward(vl_input)
     # Convert boolean tensors to int32
-    converted_outputs = {}
+    backbone_outputs = {}
     for key, value in outputs.items():
         if torch.is_tensor(value) and value.dtype == torch.bool:
-            converted_outputs[key] = value.to(torch.int32)
+            backbone_outputs[key] = value.to(torch.int32)
         else:
-            converted_outputs[key] = value
-    return converted_outputs
+            backbone_outputs[key] = value
+    return backbone_outputs
 
 
 def _action_head_get_action_with_bool(self, backbone_outputs, action_inputs, initial_noise=None):
     """
     Action head get_action that converts int32 mask inputs back to bool.
     Calls self._original_get_action which is the original get_action method.
+
+    The returned dict's ``action_pred`` key is renamed to ``normalized_action``
+    so the leapp-generated ONNX output name (``normalized_action``) already
+    matches the parameter name that the downstream ``decode_action`` node uses
+    to consume this tensor.  Without this rename, leapp's reconciler renames
+    the action_head output to ``normalized_action`` only in the yaml metadata
+    and the actual ONNX file keeps the original ``output1_action_pred`` name.
     """
     # Convert int32 tensors to bool inline (no external function calls for leapp compatibility)
     converted_backbone_outputs = {}
@@ -54,8 +69,20 @@ def _action_head_get_action_with_bool(self, backbone_outputs, action_inputs, ini
             converted_backbone_outputs[k] = v.to(torch.bool)
         else:
             converted_backbone_outputs[k] = v
-    
-    return self._original_get_action(converted_backbone_outputs, action_inputs, initial_noise=initial_noise)
+
+    # Call the original method.  We rename ``action_pred`` -> ``normalized_action``
+    # in the returned dict so that producer/consumer names align across the leapp
+    # graph (the downstream ``decode_action`` consumes this tensor under the
+    # name ``normalized_action``).  The rename is inlined and produces a fresh
+    # dict literal because leapp uses local-variable names as a tensor-name
+    # prefix; using a named intermediate variable would leak that name into the
+    # exported ONNX output names.
+    return {
+        ("normalized_action" if k == "action_pred" else k): v
+        for k, v in self._original_get_action(
+            converted_backbone_outputs, action_inputs, initial_noise=initial_noise
+        ).items()
+    }
 
 
 def get_action_traceable(self, data, initial_noise=None):
@@ -119,24 +146,49 @@ def get_action_traceable(self, data, initial_noise=None):
     collated_inputs = self.collate_fn(processed_inputs)
     collated_inputs = _rec_to_dtype(collated_inputs, dtype=torch.float32)
     
-    # Annotate outputs for export
-    static_outputs = {
-        'input_ids': collated_inputs['inputs']['input_ids'],
-        'attention_mask': collated_inputs['inputs']['attention_mask'],
-        'image_sizes': collated_inputs['inputs']['image_sizes'],
-        'embodiment_id': collated_inputs['inputs']['embodiment_id']
-    }
+    # Annotate outputs for export.
+    #
+    # The output dicts below mirror the parameter-name structure that downstream
+    # consumers (backbone, action_head, decode_action) use for these tensors.
+    # leapp names tensors by walking the dict keys (parent_key + "_" + child_key
+    # via flatten_io_structure), so producing pre-flattened names like
+    # ``vl_input_pixel_values`` here makes the producer's output names already
+    # equal to the consumer's input names.  When that alignment holds, leapp's
+    # cross-node name reconciler is a no-op and the yaml metadata stays
+    # consistent with the actual ONNX graph.
     annotate.output_tensors(
         'preprocess_video',
-        {'pixel_values': collated_inputs['inputs']['pixel_values']},
-        static_outputs=static_outputs,
+        # The non-static "live" tensor that the ONNX graph computes.
+        # backbone consumes this as ``vl_input.pixel_values`` and action_head
+        # consumes it as ``vl_input.pixel_values`` as well, so we name it
+        # ``vl_input.pixel_values`` here too.
+        {'vl_input': {'pixel_values': collated_inputs['inputs']['pixel_values']}},
+        # Static outputs (constants baked into the graph) -- backbone reads
+        # ``vl_input.{input_ids,attention_mask}`` and action_head reads
+        # ``action_inputs.{image_sizes,embodiment_id}`` plus
+        # ``vl_input.{input_ids,attention_mask}``.  Mirror that structure.
+        static_outputs={
+            'vl_input': {
+                'input_ids': collated_inputs['inputs']['input_ids'],
+                'attention_mask': collated_inputs['inputs']['attention_mask'],
+            },
+            'action_inputs': {
+                'image_sizes': collated_inputs['inputs']['image_sizes'],
+                'embodiment_id': collated_inputs['inputs']['embodiment_id'],
+            },
+        },
         export_with='onnx'
     )
 
+    # preprocess_state outputs feed both action_head (via ``action_inputs.state``)
+    # and decode_action (via ``state[i]`` -- a list of dicts the consumer
+    # named ``state``, hence the rename of ``reference`` -> ``state`` below).
     annotate.output_tensors(
         'preprocess_state',
-        {'state': collated_inputs['inputs']['state'],
-        'reference': states},
+        {
+            'action_inputs': {'state': collated_inputs['inputs']['state']},
+            'state': states,
+        },
         export_with='onnx-torchscript'
     )
 
@@ -156,7 +208,10 @@ def get_action_traceable(self, data, initial_noise=None):
     
     with torch.inference_mode():
         model_pred = self.model.get_action(**collated_inputs, initial_noise=initial_noise)
-    normalized_action = model_pred["action_pred"].float()
+    # ``_action_head_get_action_with_bool`` renamed action_pred -> normalized_action
+    # so producer/consumer names align across the leapp graph.  See the wrapper
+    # docstring above for the rationale.
+    normalized_action = model_pred["normalized_action"].float()
 
     normalized_action, states = annotate.input_tensors('decode_action', 
         {'normalized_action': normalized_action, 'state': states},


### PR DESCRIPTION
Follow-up to #4 and #5. Addresses the recurring deploy-time pain where the generated yaml's tensor names don't match the actual ONNX file's input/output names, forcing the deploy team to hand-edit the yaml after every export.

## Problem

leapp emits the yaml metadata + per-node ONNX files from the same traced graph, but the names disagree.

Concrete example before this PR:

\`\`\`
preprocess_video.onnx actually outputs: ['pixel_values_0', 'input_ids', 'attention_mask', 'image_sizes', 'embodiment_id']
yaml claims preprocess_video outputs:   ['vl_input_pixel_values_0', 'vl_input_input_ids', 'vl_input_attention_mask',
                                         'action_inputs_image_sizes', 'action_inputs_embodiment_id']
\`\`\`

Why: backbone (consumer) takes a dict parameter named \`vl_input\`, so leapp names backbone's inputs \`vl_input_*\`. preprocess_video (producer) outputs the same tensors with their plain dict-key names. leapp's cross-node reconciler rewrites the producer's TensorDescription names to match the consumer — but only in the yaml metadata, **after** the ONNX files have been compiled with the original names.

Same pattern for backbone outputs (\`converted_outputs_*\` in ONNX, \`backbone_outputs_*\` in yaml), preprocess_state (\`state\`/\`reference\` in ONNX, \`action_inputs_state\`/\`state_0_*\` in yaml), and action_head's output (\`output1_action_pred\` in ONNX, \`normalized_action\` in yaml).

## Fix

Pre-shape the producer's output dicts so the names already match the consumer's parameter structure. When alignment holds, leapp's reconciler is a no-op and yaml + ONNX agree by construction.

Specifically:

| Edge | What changed |
|------|--------------|
| preprocess_video → backbone / action_head | Output dict nested as \`{'vl_input': {'pixel_values': ...}}\` and \`{'action_inputs': {...}}\` so leapp produces \`vl_input_*\` / \`action_inputs_*\` names directly |
| preprocess_state → action_head | State tensor wrapped in \`{'action_inputs': {'state': ...}}\` |
| preprocess_state → decode_action | \`reference\` renamed to \`state\` (the param name decode_action uses) |
| backbone return → action_head | Local variable renamed \`converted_outputs\` → \`backbone_outputs\` so leapp uses the consumer's dict-name as the prefix |
| action_head return → decode_action | Returns \`{'normalized_action': ..., ...}\` instead of \`{'action_pred': ...}\` |

## Validation

Tested against a G1 \`NEW_EMBODIMENT\` finetune (332 episodes, full N1.6 export with effort + navigate + base_height outputs).

**Before**: 0 of 5 model files had yaml/ONNX name agreement. Deploy team hand-edited every export.

**After**: 4 of 5 model files have full yaml/ONNX name agreement (preprocess_video, preprocess_state, backbone, decode_action).

Verified with this script:

\`\`\`python
import yaml, onnx
y = yaml.safe_load(open('exported_g1.../<name>.yaml'))
for name, model_def in y['models'].items():
    m = onnx.load(f'.../<name>.onnx', load_external_data=False)
    yaml_io  = sorted([t['name'] for t in model_def['outputs']])
    onnx_io  = sorted([o.name for o in m.graph.output])
    assert yaml_io == onnx_io, f'{name}: yaml says {yaml_io}, onnx says {onnx_io}'
\`\`\`

## Remaining mismatches (action_head)

Two issues that require either a leapp-level fix or a more invasive wrapper refactor:

1. **3 input tensors** (\`pixel_values_0\`, \`input_ids\`, \`attention_mask\`) come from preprocess_video, are consumed by both backbone (via \`vl_input.*\`) and action_head (via \`action_inputs.*\`). When one tensor flows to two consumers under different names, leapp's reconciler picks one for the yaml; the other ONNX file keeps its own name. Fixable by aligning action_head's parameter to match backbone (move these 3 from \`action_inputs\` to \`vl_input\`), but that's a wrapper-signature refactor beyond this PR's scope.

2. **action_head output**: ONNX exports as \`output1_normalized_action\` (leapp prefixes positional return values with \`output1_\`); yaml claims \`normalized_action\` (after reconciler). This is a leapp-internal convention; not fixable from this repo without leapp changes.

Both are acceptable as known limitations for now — deploy team's hand-edit list shrinks from 5 model files to 1.