### PR TITLE
Make export work end-to-end on a fresh host

### DIFF
--- a/export/README.md
+++ b/export/README.md
@@ -61,6 +61,7 @@ uv run python export/export_with_leapp.py
 | `--embodiment_tag` | str | `gr1` | Embodiment tag for the robot |
 | `--video_backend` | str | `torchcodec` | Video decoding backend |
 | `--output_name` | str | `exported_gr00t` | Name for the exported model directory |
+| `--joint_config` | str | `None` (auto-detect) | Path to a JSON file with joint names. Required for G1 fine-tunes to get real ROS joint names in the exported YAML — see `export/data/g1_joints.json`. |
 
 **Example:**
 
@@ -79,6 +80,23 @@ Once downloaded you can run the export using:
 
 ```bash
 uv run python export/export_with_leapp.py --model_path nvidia/GR00T-N1.6-G1-PnPAppleToPlate --embodiment_tag unitree_g1 --dataset_path <path to downloaded dataset>
+```
+
+### For Custom G1 Fine-Tunes (NEW_EMBODIMENT)
+
+For fine-tuned policies registered under `EmbodimentTag.NEW_EMBODIMENT` (the
+default path produced by the fine-tune tutorial), pass `--joint_config` so the
+exported YAML embeds real ROS joint names (`left_shoulder_pitch_joint`, ...)
+instead of placeholders. The deploy stack maps joint commands by name, so this
+matters for downstream control.
+
+```bash
+uv run python export/export_with_leapp.py \
+    --model_path <path to fine-tuned checkpoint> \
+    --embodiment_tag new_embodiment \
+    --dataset_path <path to lerobot dataset> \
+    --joint_config export/data/g1_joints.json \
+    --output_name <export-name>
 ```
 
 

--- a/export/data/g1_joints.json
+++ b/export/data/g1_joints.json
@@ -1,0 +1,128 @@
+{
+  "state": {
+    "left_leg": [
+      "left_hip_pitch_joint",
+      "left_hip_roll_joint",
+      "left_hip_yaw_joint",
+      "left_knee_joint",
+      "left_ankle_pitch_joint",
+      "left_ankle_roll_joint"
+    ],
+    "right_leg": [
+      "right_hip_pitch_joint",
+      "right_hip_roll_joint",
+      "right_hip_yaw_joint",
+      "right_knee_joint",
+      "right_ankle_pitch_joint",
+      "right_ankle_roll_joint"
+    ],
+    "waist": [
+      "waist_yaw_joint",
+      "waist_roll_joint",
+      "waist_pitch_joint"
+    ],
+    "left_arm": [
+      "left_shoulder_pitch_joint",
+      "left_shoulder_roll_joint",
+      "left_shoulder_yaw_joint",
+      "left_elbow_joint",
+      "left_wrist_roll_joint",
+      "left_wrist_pitch_joint",
+      "left_wrist_yaw_joint"
+    ],
+    "right_arm": [
+      "right_shoulder_pitch_joint",
+      "right_shoulder_roll_joint",
+      "right_shoulder_yaw_joint",
+      "right_elbow_joint",
+      "right_wrist_roll_joint",
+      "right_wrist_pitch_joint",
+      "right_wrist_yaw_joint"
+    ],
+    "left_hand": [
+      "left_hand_thumb_0_joint",
+      "left_hand_thumb_1_joint",
+      "left_hand_thumb_2_joint",
+      "left_hand_middle_0_joint",
+      "left_hand_middle_1_joint",
+      "left_hand_index_0_joint",
+      "left_hand_index_1_joint"
+    ],
+    "right_hand": [
+      "right_hand_thumb_0_joint",
+      "right_hand_thumb_1_joint",
+      "right_hand_thumb_2_joint",
+      "right_hand_index_0_joint",
+      "right_hand_index_1_joint",
+      "right_hand_middle_0_joint",
+      "right_hand_middle_1_joint"
+    ]
+  },
+  "action": {
+    "left_leg": [
+      "left_hip_pitch_joint",
+      "left_hip_roll_joint",
+      "left_hip_yaw_joint",
+      "left_knee_joint",
+      "left_ankle_pitch_joint",
+      "left_ankle_roll_joint"
+    ],
+    "right_leg": [
+      "right_hip_pitch_joint",
+      "right_hip_roll_joint",
+      "right_hip_yaw_joint",
+      "right_knee_joint",
+      "right_ankle_pitch_joint",
+      "right_ankle_roll_joint"
+    ],
+    "waist": [
+      "waist_yaw_joint",
+      "waist_roll_joint",
+      "waist_pitch_joint"
+    ],
+    "left_arm": [
+      "left_shoulder_pitch_joint",
+      "left_shoulder_roll_joint",
+      "left_shoulder_yaw_joint",
+      "left_elbow_joint",
+      "left_wrist_roll_joint",
+      "left_wrist_pitch_joint",
+      "left_wrist_yaw_joint"
+    ],
+    "right_arm": [
+      "right_shoulder_pitch_joint",
+      "right_shoulder_roll_joint",
+      "right_shoulder_yaw_joint",
+      "right_elbow_joint",
+      "right_wrist_roll_joint",
+      "right_wrist_pitch_joint",
+      "right_wrist_yaw_joint"
+    ],
+    "left_hand": [
+      "left_hand_index_0_joint",
+      "left_hand_index_1_joint",
+      "left_hand_middle_0_joint",
+      "left_hand_middle_1_joint",
+      "left_hand_thumb_0_joint",
+      "left_hand_thumb_1_joint",
+      "left_hand_thumb_2_joint"
+    ],
+    "right_hand": [
+      "right_hand_index_0_joint",
+      "right_hand_index_1_joint",
+      "right_hand_middle_0_joint",
+      "right_hand_middle_1_joint",
+      "right_hand_thumb_0_joint",
+      "right_hand_thumb_1_joint",
+      "right_hand_thumb_2_joint"
+    ],
+    "navigate_command": [
+      "nav_vx",
+      "nav_vy",
+      "nav_vyaw"
+    ],
+    "base_height_command": [
+      "base_height"
+    ]
+  }
+}

--- a/export/utils.py
+++ b/export/utils.py
@@ -9,6 +9,7 @@ from gr00t.data.types import MessageType
 from gr00t.data.embodiment_tags import EmbodimentTag
 from gr00t.data.dataset.lerobot_episode_loader import LeRobotEpisodeLoader
 from gr00t.data.dataset.sharded_single_step_dataset import extract_step_data
+from gr00t.data.stats import ensure_stats
 import random
 import numpy as np
 
@@ -127,7 +128,8 @@ def get_policy_and_dataset(
 
     modality_config = policy.get_modality_config()
 
-    # Create the dataset
+    ensure_stats(dataset_path, embodiment_tag, modality_config=modality_config)
+
     dataset = LeRobotEpisodeLoader(
         dataset_path=dataset_path,
         modality_configs=modality_config,

--- a/gr00t/data/dataset/factory.py
+++ b/gr00t/data/dataset/factory.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 import numpy as np
-import torch
 from tqdm import tqdm
 
 from gr00t.configs.base_config import Config
@@ -22,8 +21,7 @@ from gr00t.data.dataset.sharded_mixture_dataset import ShardedMixtureDataset
 from gr00t.data.dataset.sharded_single_step_dataset import ShardedSingleStepDataset
 from gr00t.data.embodiment_tags import EmbodimentTag
 from gr00t.data.interfaces import BaseProcessor
-from gr00t.data.stats import generate_rel_stats, generate_stats
-from gr00t.experiment.dist_utils import barrier
+from gr00t.data.stats import ensure_stats
 
 
 class DatasetFactory:
@@ -54,14 +52,7 @@ class DatasetFactory:
                 embodiment_tag = dataset_spec.embodiment_tag
                 assert embodiment_tag is not None, "Embodiment tag is required"
                 assert self.config.data.mode == "single_turn", "Only single turn mode is supported"
-                if torch.distributed.is_initialized():
-                    if torch.distributed.get_rank() == 0:
-                        generate_stats(dataset_path)
-                        generate_rel_stats(dataset_path, EmbodimentTag(embodiment_tag))
-                else:
-                    generate_stats(dataset_path)
-                    generate_rel_stats(dataset_path, EmbodimentTag(embodiment_tag))
-                barrier()
+                ensure_stats(dataset_path, embodiment_tag)
                 dataset = ShardedSingleStepDataset(
                     dataset_path=dataset_path,
                     embodiment_tag=EmbodimentTag(embodiment_tag),

--- a/gr00t/data/stats.py
+++ b/gr00t/data/stats.py
@@ -250,6 +250,31 @@ def generate_rel_stats(dataset_path: Path | str, embodiment_tag: EmbodimentTag) 
         json.dump(to_json_serializable(dict(stats)), f, indent=4)
 
 
+def ensure_stats(
+    dataset_path: Path | str,
+    embodiment_tag: "str | EmbodimentTag",
+    modality_config: dict | None = None,
+) -> None:
+    """Ensure ``meta/stats.json`` and ``meta/relative_stats.json`` exist for *dataset_path*.
+
+    Idempotent. Distributed-safe: only rank 0 writes; all ranks barrier. If
+    *modality_config* is provided and the tag is not in ``MODALITY_CONFIGS``,
+    it is registered first so ``generate_rel_stats`` can resolve the action
+    config.
+    """
+    import torch
+
+    from gr00t.experiment.dist_utils import barrier
+
+    tag = EmbodimentTag.resolve(embodiment_tag)
+    if modality_config is not None and tag.value not in MODALITY_CONFIGS:
+        MODALITY_CONFIGS[tag.value] = modality_config
+    if not torch.distributed.is_initialized() or torch.distributed.get_rank() == 0:
+        generate_stats(dataset_path)
+        generate_rel_stats(dataset_path, tag)
+    barrier()
+
+
 def main(
     dataset_path: Path | str,
     embodiment_tag: EmbodimentTag,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,16 +37,17 @@ dependencies = [
     "numpy==1.26.4",
     "omegaconf==2.3.0",
     "scipy==1.15.3",
-    # x86_64: PyPI wheel; aarch64 Linux: prebuilt wheel in scripts/deployment/dgpu/wheels/
+    # Aarch64 (Jetson Thor / GB200) wheels for torchcodec and flash-attn are not
+    # currently shipped in this repo. Until they are, aarch64 use is unsupported
+    # and these deps install only on x86_64.
     "torchcodec==0.4.0; platform_machine == 'x86_64'",
-    "torchcodec==0.10.0a0; platform_machine == 'aarch64' and sys_platform == 'linux'",
     "wandb==0.23.0",
     "pyzmq==27.0.1",
     # deepspeed has no aarch64 Linux wheel
     "deepspeed==0.17.6; platform_machine != 'aarch64' or sys_platform != 'linux'",
     # triton is needed on aarch64 (GB200) but ships with torch on x86_64
     "triton==3.3.1; sys_platform == 'linux' and platform_machine == 'aarch64'",
-    "flash-attn==2.7.4.post1",
+    "flash-attn==2.7.4.post1; platform_machine == 'x86_64'",
     "onnx>=1.20.0",
     # cu12 wheels only exist for x86_64; Blackwell / aarch64 requires cu13.
     "tensorrt-cu12>=10.15.1.29; platform_machine == 'x86_64'",
@@ -71,7 +72,6 @@ include = ["gr00t*"]
 [tool.uv]
 required-environments = [
     "sys_platform == 'linux' and platform_machine == 'x86_64'",
-    "sys_platform == 'linux' and platform_machine == 'aarch64'",
 ]
 
 [tool.uv.sources]
@@ -87,10 +87,6 @@ triton = [
 flash-attn = [
     { url = "https://github.com/Dao-AILab/flash-attention/releases/download/v2.7.4.post1/flash_attn-2.7.4.post1+cu12torch2.7cxx11abiFALSE-cp310-cp310-linux_x86_64.whl", marker = "sys_platform == 'linux' and platform_machine == 'x86_64' and python_version == '3.10'" },
     { url = "https://github.com/Dao-AILab/flash-attention/releases/download/v2.7.4.post1/flash_attn-2.7.4.post1+cu12torch2.7cxx11abiFALSE-cp312-cp312-linux_x86_64.whl", marker = "sys_platform == 'linux' and platform_machine == 'x86_64' and python_version == '3.12'" },
-    { path = "scripts/deployment/dgpu/wheels/flash_attn-2.7.4.post1-cp310-cp310-linux_aarch64.whl", marker = "sys_platform == 'linux' and platform_machine == 'aarch64' and python_version == '3.10'" },
-]
-torchcodec = [
-    { path = "scripts/deployment/dgpu/wheels/torchcodec-0.10.0a0-cp310-cp310-linux_aarch64.whl", marker = "sys_platform == 'linux' and platform_machine == 'aarch64'" },
 ]
 
 [tool.uv.extra-build-dependencies]


### PR DESCRIPTION
## Summary

Three fixes to make the export flow work end-to-end from a fresh clone on a fresh host.

### 1. Remove dead aarch64 wheel references from `pyproject.toml`

Commit `049e29f` deleted `scripts/deployment/dgpu/wheels/` but left references to those wheels in `[tool.uv.sources]` and aarch64 dependency declarations. Fresh `uv sync` currently fails with:

```
error: Distribution not found at:
  file:///.../scripts/deployment/dgpu/wheels/torchcodec-0.10.0a0-cp310-cp310-linux_aarch64.whl
```

Cleaned up only the entries that depended on the deleted wheels:
- Removed path-source entries for `flash-attn` (aarch64) and `torchcodec` (aarch64) from `[tool.uv.sources]`
- Scoped `flash-attn` and `torchcodec` deps to `x86_64`
- Removed `aarch64` from `[tool.uv.required-environments]`
- Added a comment noting aarch64 is currently unsupported until wheels return

Index-based aarch64 deps (`triton`, `tensorrt-cu13`, deepspeed marker) are unchanged — they didn't depend on the deleted wheels.

**Verified:** fresh `uv sync --python 3.10` on x86_64 completes cleanly.

### 2. Ship `g1_joints.json` in the export repo

The `--joint_config` flag currently requires users to point at a JSON file that lives in the deploy stack's `isaac_ros_unitree_g1_recorder` package:

```bash
--joint_config \$(ros2 pkg prefix isaac_ros_unitree_g1_recorder)/share/.../g1_joints.json
```

Means the deploy stack must be installed before you can export. Heavy dependency for a 3 KB metadata file.

This ships the same file at `export/data/g1_joints.json` so the export command simplifies to:

```bash
--joint_config export/data/g1_joints.json
```

Content matches the deploy stack's current `g1_joints.json` byte for byte.

Also updated `export/README.md` to document the `--joint_config` argument and added an example for fine-tuned G1 policies (NEW_EMBODIMENT).

### 3. Auto-generate dataset stats on demand so export works on fresh hosts

\`LeRobotEpisodeLoader\` asserts \`meta/stats.json\` exists. The trainer's \`DatasetFactory\` generates stats inline before instantiating the loader, but the exporter does not — so the typical \"finetune on host A, export on host B\" flow aborts with:

\`\`\`
AssertionError: .../meta/stats.json does not exist for ..., please use gr00t/data/stats.py to generate it
\`\`\`

Extracted the rank-gated \`generate_stats\` + \`generate_rel_stats\` + \`barrier\` block into a single \`ensure_stats\` helper in \`gr00t/data/stats.py\`. Trainer \`factory.py\` now calls it (removing the duplicated block); exporter calls it before \`LeRobotEpisodeLoader\` instantiation, passing the policy's modality config so \`generate_rel_stats\` can resolve the action config for embodiment tags not pre-registered via \`--modality-config-path\`.

**Verified:** with no \`stats.json\` / \`relative_stats.json\` on disk, the documented export command auto-generates both and produces a complete bundle.

## Test plan

- [x] Fresh clone → \`uv sync --python 3.10\` succeeds on x86_64
- [x] \`uv run python export/export_with_leapp.py --joint_config export/data/g1_joints.json ...\` completes and produces a bundle with real ROS joint names in the YAML (not placeholders)
- [x] Export succeeds on a host where the dataset has never been through the trainer (no pre-existing stats files)

## Not in this PR

- A possible follow-up: similar dict-access fix at \`gr00t_n1d7.py:195+\` (\`action_input.embodiment_id\`, \`action_input.state\`) — same dict-vs-dataclass class of bug you just fixed at line 192 with MR #7. We haven't seen this crash in practice (only \`backbone_output\` was confirmed dictified by deepspeed in our testing), so leaving it out. Happy to send a follow-up if it surfaces.